### PR TITLE
adding missing unit tests for agent-related functions

### DIFF
--- a/mdagent/tools/base_tools/simulation_tools/create_simulation.py
+++ b/mdagent/tools/base_tools/simulation_tools/create_simulation.py
@@ -1,8 +1,9 @@
 import textwrap
 from typing import Optional
 
-from langchain import LLMChain, PromptTemplate
 from langchain.base_language import BaseLanguageModel
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
 from langchain.tools import BaseTool
 from pydantic import BaseModel, Field
 

--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -9,8 +9,9 @@ import textwrap
 from typing import Any, Dict, List, Optional, Type
 
 import langchain
-from langchain import LLMChain, PromptTemplate
 from langchain.base_language import BaseLanguageModel
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
 from langchain.tools import BaseTool
 from openmm import (
     AndersenThermostat,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -5,6 +5,7 @@ import pytest
 
 from mdagent.subagents.agents.action import Action
 from mdagent.subagents.subagent_fxns import Iterator
+from mdagent.subagents.subagent_setup import SubAgentSettings
 from mdagent.utils import PathRegistry
 
 
@@ -20,7 +21,8 @@ def action(path_registry):
 
 @pytest.fixture
 def iterator(path_registry):
-    return Iterator(path_registry)
+    settings = SubAgentSettings(path_registry=None)
+    return Iterator(path_registry=path_registry, subagent_settings=settings)
 
 
 def test_exec_code(action):
@@ -37,8 +39,8 @@ def test_exec_code(action):
 def test_extract_code(action):
     # test1 is valid code
     sample_output = (
-        "Here's some code:\n```"
-        "\ndef sample_function():\n    return 'Hello, World!'\n```"
+        "Here's some code. \nCode:\n```python\n"
+        "def sample_function():\n    return 'Hello, World!'\n```"
     )
     # Call the _extract_code function with the sample output
     code, fxn_name = action._extract_code(sample_output)
@@ -51,7 +53,7 @@ def test_extract_code(action):
     # test2 is two types of invalid code
     no_code = "text without code."
     code_1, fxn_name_1 = action._extract_code(no_code)
-    no_fxn = "Here's some code:\n```python\nx = 10\ny = 20\n```"
+    no_fxn = "Code:\n```python\nx = 10\ny = 20\n```"
     code_2, fxn_name_2 = action._extract_code(no_fxn)
     assert code_2 == "x = 10\ny = 20"
     assert code_1 is None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -163,3 +163,16 @@ def test_execute_skill_function(skill_manager):
     with pytest.raises(ValueError) as excinfo:
         skill_manager.execute_skill_function("nonexistent_tool", path_registry)
     assert "Code for nonexistent_tool not found" in str(excinfo.value)
+
+
+def test_check_arguments_success(skill_manager):
+    skill_manager.skills = {
+        "sample_tool": {"arguments": [{"name": "arg1"}, {"name": "arg2"}]}
+    }
+    try:
+        skill_manager._check_arguments("sample_tool", arg1=5, arg2=10)
+    except ValueError:
+        pytest.fail("ValueError raised unexpectedly")
+    with pytest.raises(ValueError) as excinfo:
+        skill_manager._check_arguments("sample_tool", arg1=5)
+    assert "Missing arguments" in str(excinfo.value)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,41 @@
+import pytest
+
+from mdagent.subagents.agents.action import Action
+
+
+@pytest.fixture
+def action():
+    return Action()
+
+
+def test_exec_code(action):
+    successful_code = "print('Hello, World!')"
+    success, _ = action._exec_code(successful_code)
+    # assert success
+    assert success is True
+    error_code = "raise ValueError('Test Error')"
+    success, _ = action._exec_code(error_code)
+    # assert failure
+    assert success is False
+
+
+def test_extract_code(action):
+    # test1 is valid code
+    sample_output = "Here's some code:\n```\ndef sample_function():\n    return 'Hello, World!'\n```"
+    # Call the _extract_code function with the sample output
+    code, fxn_name = action._extract_code(sample_output)
+
+    # Assert that the code and function name are correctly extracted
+    expected_code = "def sample_function():\n    return 'Hello, World!'"
+    assert code == expected_code
+    assert fxn_name == "sample_function"
+
+    # test2 is two types of invalid code
+    no_code = "text without code."
+    code_1, fxn_name_1 = action._extract_code(no_code)
+    no_fxn = "Here's some code:\n```python\nx = 10\ny = 20\n```"
+    code_2, fxn_name_2 = action._extract_code(no_fxn)
+    assert code_2 == "x = 10\ny = 20"
+    assert code_1 is None
+    assert fxn_name_1 is None
+    assert fxn_name_2 is None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -143,3 +143,23 @@ def test_add_new_tool(skill_manager):
         assert skill_manager.update_skill_library.call_args[0][0].__name__ == fxn_name
         assert skill_manager.update_skill_library.call_args[0][1] == code
         assert skill_manager.update_skill_library.call_args[0][2] == "Sample Docstring"
+
+
+def test_execute_skill_function(skill_manager):
+    path_registry = MagicMock()
+    path_registry.list_path_names.return_value = ["path1", "path2"]
+    skill_manager.skills = {
+        "sample_tool": {"code": "def sample_tool(arg1, arg2):\n    return arg1 + arg2"}
+    }
+    with patch("os.listdir", return_value=["file1", "file2"]):
+        skill_manager._check_arguments = MagicMock()
+        message = skill_manager.execute_skill_function(
+            "sample_tool", path_registry, arg1=5, arg2=3
+        )
+
+    assert "Successfully executed code." in message
+    assert "Code Output: 8" in message
+    skill_manager.skills = {}
+    with pytest.raises(ValueError) as excinfo:
+        skill_manager.execute_skill_function("nonexistent_tool", path_registry)
+    assert "Code for nonexistent_tool not found" in str(excinfo.value)


### PR DESCRIPTION
this pr is to add the test functions for all agent-related functions that we wrote, except those that use llm calls (we can add these later if desired). This PR does not add the tool tests.

this PR also changes the imports for langchain.prompt and langchain.LLMChain to their new import locations