### PR TITLE
fixed typo in WorkPlanTool

### DIFF
--- a/mdagent/tools/subagent_tools.py
+++ b/mdagent/tools/subagent_tools.py
@@ -130,7 +130,7 @@ class WorkflowPlan(BaseTool):
             if curriculum is None:
                 return "Curriculum Agent is not initialized"
             if files == "":
-                files = self.path_registry.list_path_names()
+                files = self.subagent_settings.path_registry.list_path_names()
             rationale, decomposed_tasks = curriculum.run(
                 task, curr_tools, files, failed_tasks
             )


### PR DESCRIPTION
fixed typo in WorkPlan regarding path_registry variable name, so it can operate normally when that tool is called. 