### PR TITLE
updated SkillRetrieval and ModifyScript descriptions and names

### DIFF
--- a/mdagent/tools/base_tools/simulation_tools/create_simulation.py
+++ b/mdagent/tools/base_tools/simulation_tools/create_simulation.py
@@ -136,7 +136,7 @@ class ModifySimulationScriptInput(BaseModel):
     query: str = Field(
         ...,
         description=(
-            "Simmulation required by the user.You MUST "
+            "Simulation required by the user. You MUST "
             "specify the objective, requirements of the simulation as well "
             "as on what protein you are working."
         ),
@@ -147,8 +147,8 @@ class ModifySimulationScriptInput(BaseModel):
 class ModifyBaseSimulationScriptTool(BaseTool):
     name: str = "ModifySimulationScriptTool"
     description: str = (
-        "This tool takes a base simulation script and a user "
-        "requirement and returns a modified script. "
+        "This tool takes a base simulation script and user "
+        "requirements and returns a modified script. "
     )
 
     args_schema = ModifySimulationScriptInput

--- a/mdagent/tools/base_tools/simulation_tools/create_simulation.py
+++ b/mdagent/tools/base_tools/simulation_tools/create_simulation.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from mdagent.utils import FileType, PathRegistry
 
 
-class ModifyScriptUtils:
+class ModifySimulationScriptUtils:
     llm: Optional[BaseLanguageModel]
 
     def __init__(self, llm):
@@ -90,7 +90,7 @@ simulation.step(10000)
 
     def _prompt_summary(self, query: str, llm: BaseLanguageModel = None):
         if not llm:
-            raise ValueError("No language model provided at ModifyScriptTool")
+            raise ValueError("No language model provided at ModifySimulationScriptTool")
 
         prompt_template = (
             "You're an expert programmer and in molecular dynamics. "
@@ -132,7 +132,7 @@ simulation.step(10000)
         return "\n".join(stripped_lines)
 
 
-class ModifyScriptInput(BaseModel):
+class ModifySimulationScriptInput(BaseModel):
     query: str = Field(
         ...,
         description=(
@@ -145,13 +145,13 @@ class ModifyScriptInput(BaseModel):
 
 
 class ModifyBaseSimulationScriptTool(BaseTool):
-    name: str = "ModifyScriptTool"
+    name: str = "ModifySimulationScriptTool"
     description: str = (
         "This tool takes a base simulation script and a user "
         "requirement and returns a modified script. "
     )
 
-    args_schema = ModifyScriptInput
+    args_schema = ModifySimulationScriptInput
     llm: Optional[BaseLanguageModel]
     path_registry: Optional[PathRegistry]
 
@@ -162,7 +162,7 @@ class ModifyBaseSimulationScriptTool(BaseTool):
 
     def _run(self, *args, **input):
         if self.llm is None:  # this should not happen
-            print("No language model provided at ModifyScriptTool")
+            print("No language model provided at ModifySimulationScriptTool")
             return "llm not initialized"
         if len(args) > 0:
             return (
@@ -183,7 +183,7 @@ class ModifyBaseSimulationScriptTool(BaseTool):
         with open(base_script_path, "r") as file:
             base_script = file.read()
         base_script = "".join(base_script)
-        utils = ModifyScriptUtils(self.llm)
+        utils = ModifySimulationScriptUtils(self.llm)
 
         description = input.get("query")
         answer = utils._prompt_summary(

--- a/mdagent/tools/subagent_tools.py
+++ b/mdagent/tools/subagent_tools.py
@@ -17,10 +17,11 @@ class ExecuteSkillInputSchema(BaseModel):
 
 class RetryExecuteSkill(BaseTool):
     name = "RetryExecuteSkill"
-    description = """Only use this tool to execute a tool recently created
-    that previously failed to execute or hasn't been executed yet.
-    Make sure to include tool name and inputs arguments.
-    """
+    description = (
+        "Only use this tool to execute a tool recently created"
+        "that previously failed to execute or hasn't been executed yet."
+        "Make sure to include tool name and inputs arguments."
+    )
     subagent_settings: Optional[SubAgentSettings]
     args_schema: Optional[Type[BaseModel]] = ExecuteSkillInputSchema
 
@@ -61,9 +62,11 @@ class SkillRetrievalInput(BaseModel):
 
 class SkillRetrieval(BaseTool):
     name = "SkillRetrieval"
-    description = """Only use this tool to retrieve skills that have been
-    made during the current iteration. Use this tool less than other tools.
-    """
+    description = (
+        "Only use this tool to retrieve skills that have been "
+        "made during the current iteration. Use this tool less than other tools. "
+        "Use this if there is no tool available that can be used "
+    )
     subagent_settings: Optional[SubAgentSettings]
     args_schema: Optional[Type[BaseModel]] = SkillRetrievalInput
 

--- a/mdagent/tools/subagent_tools.py
+++ b/mdagent/tools/subagent_tools.py
@@ -63,9 +63,9 @@ class SkillRetrievalInput(BaseModel):
 class SkillRetrieval(BaseTool):
     name = "SkillRetrieval"
     description = (
-        "Only use this tool to retrieve skills that have been "
-        "made during the current iteration. Use this tool less than other tools. "
-        "Use this if there is no tool available that can be used "
+        "Only use this tool to retrieve new skills you created during "
+        "the current iteration. Use this tool less than other tools. Use "
+        "this if there is no tool available that can be used for the task."
     )
     subagent_settings: Optional[SubAgentSettings]
     args_schema: Optional[Type[BaseModel]] = SkillRetrievalInput


### PR DESCRIPTION
I got a report where SkillRetrieval tool is chosen over ModifyScript tool, when the goal is to actually modify simulation scripts (just 5 lines of code). 

Looks like mdagent 'misunderstands' what both tools are for, so I opened this PR to address this. Changing tool descriptions may be all it takes, but if it doesn't, we may consider renaming tools as well. 