### PR TITLE
80-adding-solvate-option-in-setupandrun-tool

### DIFF
--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -387,6 +387,15 @@ class SimulationFunctions:
         simulation = Simulation(modeller.topology, system, integrator)
         simulation.context.setPositions(modeller.positions)
         simulation.minimizeEnergy()
+        # save initial positions to registry
+        file_name = "initial_positions.pdb"
+        with open(file_name, "w") as f:
+            PDBFile.writeFile(
+                simulation.topology,
+                simulation.context.getState(getPositions=True).getPositions(),
+                f,
+            )
+        print("Initial Positions saved to initial_positions.pdb")
         simulation.reporters.append(PDBReporter(f"{name}.pdb", 1000))
         # reporter_args = {"reportInterval": 1000}
         reporter_args = {}
@@ -1095,6 +1104,16 @@ class OpenMMSimulation:
 
         self.simulation.minimizeEnergy()
         print("Minimization complete!")
+        top_name = f"files/pdb/{self.sim_id}_initial_positions.pdb"
+        top_description = f"Initial positions for simulation {self.sim_id}"
+        with open(top_name, "w") as f:
+            PDBFile.writeFile(
+                self.simulation.topology,
+                self.simulation.context.getState(getPositions=True).getPositions(),
+                f,
+            )
+        self.path_registry.map_path(f"top_{self.sim_id}", top_name, top_description)
+        print("Initial Positions saved to initial_positions.pdb")
         st.markdown("Minimization complete! Equilibrating...", unsafe_allow_html=True)
         print("Equilibrating...")
         _temp = self.int_params["Temperature"]
@@ -1693,7 +1712,7 @@ class SetUpandRunFunction(BaseTool):
                 if file not in FORCEFIELD_LIST:
                     error_msg += "The forcefield file is not present"
 
-        save = values.get("final", False)
+        save = values.get("save", True)
         if type(save) != bool:
             error_msg += "save must be a boolean value"
 

--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -594,6 +594,8 @@ class SetUpandRunFunctionInput(BaseModel):
             "None, HBonds, AllBonds or OnlyWater."
             "For rigidWater, you can choose from the following:\n"
             "True, False.\n"
+            "Finally, if you want to solvate the system, before the simulation,"
+            "you can set solvate to True.\n"
             "Example1:\n"
             "{'nonbondedMethod': 'NoCutoff',\n"
             "'constraints': 'None',\n"
@@ -604,7 +606,7 @@ class SetUpandRunFunctionInput(BaseModel):
             "'constraints': 'HBonds',\n"
             "'rigidWater': True,\n"
             "'constraintTolerance': 0.00001,\n"
-            "'solvate': False} "
+            "'solvate': True} "
         ),
     )
     integrator_params: Dict[str, Any] = Field(

--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -1412,9 +1412,12 @@ class SetUpandRunFunction(BaseTool):
                     try:
                         processed_params[key] = float(value)
                     except TypeError as e:
-                        error_msg += f"""Invalid ewaldErrorTolerance: {e}.
-                        If you are using null or None, just dont include
-                        as part of the parameters.\n"""
+                        error_msg += (
+                            f"Invalid ewaldErrorTolerance: {e}. "
+                            "If you are using null or None, "
+                            "just dont include it "
+                            "as part of the parameters.\n"
+                        )
                 if key == "constraints":
                     try:
                         if type(value) == str:
@@ -1427,14 +1430,19 @@ class SetUpandRunFunction(BaseTool):
                             elif value == "HAngles":
                                 processed_params[key] = HAngles
                             else:
-                                error_msg += f"""Invalid constraints. got {value}.
-                                             Try using None, HBonds, AllBonds,
-                                             HAngles"""
+                                error_msg += (
+                                    f"Invalid constraints: Got {value}. "
+                                    "Try using None, HBonds, AllBonds or "
+                                    "HAngles\n"
+                                )
                         else:
                             processed_params[key] = value
                     except TypeError as e:
-                        error_msg += f"""Invalid constraints: {e}. If you are using
-                        null or None, just dont include as part of the parameters.\n"""
+                        error_msg += (
+                            f"Invalid constraints: {e}. If you are using "
+                            "null or None, just dont include as "
+                            "part of the parameters.\n"
+                        )
                 if key == "rigidWater" or key == "rigidwater":
                     if type(value) == bool:
                         processed_params[key] = value
@@ -1443,17 +1451,42 @@ class SetUpandRunFunction(BaseTool):
                     elif value == "False":
                         processed_params[key] = False
                     else:
-                        error_msg += f"""Invalid rigidWater. got {value}.
-                                    Try using True or False.\n"""
+                        error_msg += (
+                            f"Invalid rigidWater: got {value}. "
+                            "Try using True or False.\n"
+                        )
                 if key == "constraintTolerance" or key == "constrainttolerance":
                     try:
                         processed_params[key] = float(value)
                     except ValueError as e:
-                        error_msg += f"Invalid constraintTolerance. {e}."
+                        error_msg += f"Invalid constraintTolerance: {e}."
                     except TypeError as e:
-                        error_msg += f"""Invalid constraintTolerance. {e}. If
-                        constraintTolerance is null or None,
-                        just dont include as part of the parameters.\n"""
+                        error_msg += (
+                            f"Invalid constraintTolerance: {e}. If "
+                            "constraintTolerance is null or None, "
+                            "just dont include as part of "
+                            "the parameters.\n"
+                        )
+                if key == "solvate":
+                    try:
+                        if type(value) == bool:
+                            processed_params[key] = value
+                        elif value == "True":
+                            processed_params[key] = True
+                        elif value == "False":
+                            processed_params[key] = False
+                        else:
+                            error_msg += (
+                                f"Invalid solvate: got {value}. "
+                                "Use either True or False.\n"
+                            )
+                    except TypeError as e:
+                        error_msg += (
+                            f"Invalid solvate: {e}. If solvate is null or "
+                            "None, just dont include as part of "
+                            "the parameters.\n"
+                        )
+
             return processed_params, error_msg
         if param_type == "integrator_params":
             for key, value in user_params.items():
@@ -1467,9 +1500,11 @@ class SetUpandRunFunction(BaseTool):
                     elif value == "Brownian" or value == BrownianIntegrator:
                         processed_params[key] = "Brownian"
                     else:
-                        error_msg += f"""\nInvalid integrator_type. got {value}.
-                                         Try using LangevinMiddle, Langevin,
-                                         Verlet, or Brownian."""
+                        error_msg += (
+                            f"Invalid integrator_type: got {value}. "
+                            "Try using LangevinMiddle, Langevin, "
+                            "Verlet, or Brownian.\n"
+                        )
                 if key == "Temperature" or key == "temperature":
                     temperature, msg = self.parse_temperature(value)
                     processed_params[key] = temperature
@@ -1498,8 +1533,10 @@ class SetUpandRunFunction(BaseTool):
                     elif value == "NVE":
                         processed_params[key] = "NVE"
                     else:
-                        error_msg += f"""Invalid Ensemble. got {value}.
-                                         Try using NPT, NVT, or NVE."""
+                        error_msg += (
+                            f"Invalid Ensemble. got {value}. "
+                            "Try using NPT, NVT, or NVE.\n"
+                        )
 
                 if key == "Number of Steps" or key == "number of steps":
                     processed_params[key] = int(value)
@@ -1530,6 +1567,7 @@ class SetUpandRunFunction(BaseTool):
                 "constraints": AllBonds,
                 "rigidWater": True,
                 "constraintTolerance": 0.00001,
+                "solvate": False,
             }
         integrator_params = values.get("integrator_params")
         if integrator_params:

--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -740,12 +740,12 @@ class OpenMMSimulation:
         print("Creating simulation...")
         st.markdown("Creating simulation", unsafe_allow_html=True)
         self.simulation = Simulation(
-            self.pdb.topology,
+            self.modeller.topology,
             self.system,
             self.integrator,
             Platform.getPlatformByName("CPU"),
         )
-        self.simulation.context.setPositions(self.pdb.positions)
+        self.simulation.context.setPositions(self.modeller.positions)
 
         # TEMPORARY FILE MANAGEMENT OR PATH REGISTRY MAPPING
         if self.save:
@@ -856,10 +856,10 @@ class OpenMMSimulation:
 
         # if use_constraint_tolerance:
         #    constraintTolerance = system_params.pop('constraintTolerance')
-        modeller = Modeller(pdb.topology, pdb.positions)
+        self.modeller = Modeller(pdb.topology, pdb.positions)
         if solvate:
             try:
-                modeller.addSolvent(forcefield)
+                self.modeller.addSolvent(forcefield)
             except ValueError as e:
                 print("Error adding solvent", type(e).__name__, "–", e)
                 if "No Template for" in str(e):
@@ -869,13 +869,13 @@ class OpenMMSimulation:
                 print("Trying to add solvent with 1 nm padding")
                 if "NoneType" and "value_in_unit" in str(e):
                     try:
-                        modeller.addSolvent(forcefield, padding=1 * nanometers)
+                        self.modeller.addSolvent(forcefield, padding=1 * nanometers)
                     except Exception as e:
                         print("Error adding solvent", type(e).__name__, "–", e)
                         raise (e)
-            system = forcefield.createSystem(modeller.topology, **system_params)
+            system = forcefield.createSystem(self.modeller.topology, **system_params)
         else:
-            system = forcefield.createSystem(modeller.topology, **system_params)
+            system = forcefield.createSystem(self.modeller.topology, **system_params)
 
         return system
 
@@ -1039,7 +1039,7 @@ class OpenMMSimulation:
             script_content += """
         integrator = LangevinMiddleIntegrator(temperature, friction, dt)
         integrator.setConstraintTolerance(constraintTolerance)
-        simulation = Simulation(topology, system, integrator, platform)
+        simulation = Simulation(modeller.topology, system, integrator, platform)
         simulation.context.setPositions(modeller.positions)
         """
         if integrator_type == "LangevinMiddle" and constraints == "None":


### PR DESCRIPTION
As part of my action items from yesterday meeting. 

Im adding the option to solvate the protein directly using modeller.addSolvent. This way, the agent can do a simulation directly without using packmol to just add water to the simulation. 

The prompt for testing was: 
""Simulate 1A3N in water at 280K. Dont forget to clean the protein first"

The second part is just to make it work quicker. The agent still needs the warning from the tools to then clean the file most of the time. 