### PR TITLE
Fixed ewaldErrorTolerance typo

### DIFF
--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -909,7 +909,7 @@ class OpenMMSimulation:
         nonbondedCutoff = unit_to_string(nbCo)
         constraints = self.sys_params.get("constraints", "None")
         rigidWater = self.sys_params.get("rigidWater", False)
-        ewaldErrorTolerance = {self.sys_params.get("ewaldErrorTolerance", 0.0005)}
+        ewaldErrorTolerance = self.sys_params.get("ewaldErrorTolerance", 0.0005)
         constraintTolerance = self.sys_params.get("constraintTolerance", None)
         hydrogenMass = self.sys_params.get("hydrogenMass", None)
         solvate = self.sys_params.get("solvate", False)


### PR DESCRIPTION
This pull request addresses the issue with the assignment of the ewaldErrorTolerance value in the code. 

Removed the bracket from the string to print the value
