### PR TITLE
fix barostat bug

### DIFF
--- a/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
+++ b/mdagent/tools/base_tools/simulation_tools/setup_and_run.py
@@ -275,19 +275,19 @@ class OpenMMSimulation:
             if self.sim_params["Ensemble"] == "NPT":
                 pressure = self.int_params.get("Pressure", 1.0)
 
-            if "Pressure" not in self.int_params:
-                print(
-                    "Warning: 'Pressure' not provided. ",
-                    "Using default pressure of 1.0 atm.",
-                )
+                if "Pressure" not in self.int_params:
+                    print(
+                        "Warning: 'Pressure' not provided. ",
+                        "Using default pressure of 1.0 atm.",
+                    )
 
-            self.system.addForce(
-                MonteCarloBarostat(
-                    pressure,
-                    self.int_params["Temperature"],
-                    self.sim_params.get("barostatInterval", 25),
+                self.system.addForce(
+                    MonteCarloBarostat(
+                        pressure,
+                        self.int_params["Temperature"],
+                        self.sim_params.get("barostatInterval", 25),
+                    )
                 )
-            )
 
     def setup_integrator(self):
         print("Setting up integrator...")


### PR DESCRIPTION
barostat should only be added for NPT. There's a bug where barostat is attempted to be added for NVT due to missing indents. 